### PR TITLE
Update base-cornell-utils to fix 7zip

### DIFF
--- a/packages/base-utils-cornell/config.yml
+++ b/packages/base-utils-cornell/config.yml
@@ -9,10 +9,10 @@ Install:         #Latest version of app is being automatically downloaded in the
     Arguments:  '/qn'        ## Silent installation switches/parmeters
     ExitCodes:  [0]  
   
-  - File:       '%TOOLS_DIR%\7zip.msi' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
-    FileType:   'msi'
-    Arguments:  '/q'
-    ExitCodes:  [0]
+#  - File:       '%TOOLS_DIR%\7zip.msi' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
+#    FileType:   'msi'
+#    Arguments:  '/q'
+#    ExitCodes:  [0]
 
 #  - File:       '%TOOLS_DIR%\NotePadPlusPlus.exe' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
 #    FileType:   'exe'
@@ -20,11 +20,11 @@ Install:         #Latest version of app is being automatically downloaded in the
 #    ExitCodes:  [0]
 
 Applications:
-    Sevenzip:
-        DisplayName:    '7-Zip'
-        Path:           '%PROGRAMFILES%\7-Zip\7zFM.exe'
-        LaunchParams:   ''
-        WorkDir:        ''
+#    Sevenzip:
+#        DisplayName:    '7-Zip'
+#        Path:           '%PROGRAMFILES%\7-Zip\7zFM.exe'
+#        LaunchParams:   ''
+#        WorkDir:        ''
         
     Edge:
         DisplayName:    'Microsoft Edge'

--- a/packages/base-utils-cornell/config.yml
+++ b/packages/base-utils-cornell/config.yml
@@ -14,10 +14,10 @@ Install:         #Latest version of app is being automatically downloaded in the
     Arguments:  '/q'
     ExitCodes:  [0]
 
-  - File:       '%TOOLS_DIR%\NotePadPlusPlus.exe' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
-    FileType:   'exe'
-    Arguments:  '/noUpdater /S'
-    ExitCodes:  [0]
+#  - File:       '%TOOLS_DIR%\NotePadPlusPlus.exe' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
+#    FileType:   'exe'
+#    Arguments:  '/noUpdater /S'
+#    ExitCodes:  [0]
 
 Applications:
     Sevenzip:
@@ -32,11 +32,11 @@ Applications:
         LaunchParams:   'https://it.cornell.edu/students'
         WorkDir:        ''
     
-    NotepadPP:
-        DisplayName:    'Notepad++'
-        Path:           '%PROGRAMFILES%\Notepad++\notepad++.exe'
-        LaunchParams:   ''
-        WorkDir:        ''
+#    NotepadPP:
+#        DisplayName:    'Notepad++'
+#        Path:           '%PROGRAMFILES%\Notepad++\notepad++.exe'
+#        LaunchParams:   ''
+#        WorkDir:        ''
         
     Chrome:
         DisplayName:    'Google Chrome'

--- a/packages/base-utils-cornell/config.yml
+++ b/packages/base-utils-cornell/config.yml
@@ -1,6 +1,6 @@
 Id:             'base-utils-cornell'
 Description:    'Base Tools for most images'
-Version:        '1.0.0'
+Version:        '1.0.1'
 
     
 Install:         #Latest version of app is being automatically downloaded in the preinstall.ps1 script

--- a/packages/base-utils-cornell/config.yml
+++ b/packages/base-utils-cornell/config.yml
@@ -14,10 +14,10 @@ Install:         #Latest version of app is being automatically downloaded in the
 #    Arguments:  '/q'
 #    ExitCodes:  [0]
 
-#  - File:       '%TOOLS_DIR%\NotePadPlusPlus.exe' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
-#    FileType:   'exe'
-#    Arguments:  '/noUpdater /S'
-#    ExitCodes:  [0]
+  - File:       '%TOOLS_DIR%\NotePadPlusPlus.exe' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
+    FileType:   'exe'
+    Arguments:  '/noUpdater /S'
+    ExitCodes:  [0]
 
 Applications:
 #    Sevenzip:
@@ -32,11 +32,11 @@ Applications:
         LaunchParams:   'https://it.cornell.edu/students'
         WorkDir:        ''
     
-#    NotepadPP:
-#        DisplayName:    'Notepad++'
-#        Path:           '%PROGRAMFILES%\Notepad++\notepad++.exe'
-#        LaunchParams:   ''
-#        WorkDir:        ''
+    NotepadPP:
+        DisplayName:    'Notepad++'
+        Path:           '%PROGRAMFILES%\Notepad++\notepad++.exe'
+        LaunchParams:   ''
+        WorkDir:        ''
         
     Chrome:
         DisplayName:    'Google Chrome'

--- a/packages/base-utils-cornell/config.yml
+++ b/packages/base-utils-cornell/config.yml
@@ -9,10 +9,10 @@ Install:         #Latest version of app is being automatically downloaded in the
     Arguments:  '/qn'        ## Silent installation switches/parmeters
     ExitCodes:  [0]  
   
-#  - File:       '%TOOLS_DIR%\7zip.msi' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
-#    FileType:   'msi'
-#    Arguments:  '/q'
-#    ExitCodes:  [0]
+  - File:       '%TOOLS_DIR%\7zip.msi' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
+    FileType:   'msi'
+    Arguments:  '/q'
+    ExitCodes:  [0]
 
   - File:       '%TOOLS_DIR%\NotePadPlusPlus.exe' #Latest version of app is being automatically downloaded in the preinstall.ps1 script
     FileType:   'exe'
@@ -20,11 +20,11 @@ Install:         #Latest version of app is being automatically downloaded in the
     ExitCodes:  [0]
 
 Applications:
-#    Sevenzip:
-#        DisplayName:    '7-Zip'
-#        Path:           '%PROGRAMFILES%\7-Zip\7zFM.exe'
-#        LaunchParams:   ''
-#        WorkDir:        ''
+    Sevenzip:
+        DisplayName:    '7-Zip'
+        Path:           '%PROGRAMFILES%\7-Zip\7zFM.exe'
+        LaunchParams:   ''
+        WorkDir:        ''
         
     Edge:
         DisplayName:    'Microsoft Edge'

--- a/packages/base-utils-cornell/tools/preinstall.ps1
+++ b/packages/base-utils-cornell/tools/preinstall.ps1
@@ -11,10 +11,10 @@ Start-BitsTransfer "https://dl.google.com/edgedl/chrome/install/GoogleChromeStan
 ## Notepad ++ Download
 ##example after website changes April 2026
 ##https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.9.3/npp.8.9.3.Installer.x64.exe
-#$linkPath = ((Invoke-WebRequest -URI https://notepad-plus-plus.org -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "/downloads/v*").href 
-#$downloadurl = "https://notepad-plus-plus.org$linkpath"
+$linkPath = ((Invoke-WebRequest -URI https://notepad-plus-plus.org -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "/downloads/v*").href 
+$downloadurl = "https://notepad-plus-plus.org$linkpath"
 
 
 #$downloadurl = "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/"
-#$NotePadPlusPlus = ((Invoke-WebRequest -URI $downloadurl -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "*npp.*.installer.x64.exe").href | Select-Object -Index 0
-#Start-BitsTransfer "$NotePadPlusPlus" -Destination "$TOOLS_DIR\NotePadPlusPlus.exe"
+$NotePadPlusPlus = ((Invoke-WebRequest -URI $downloadurl -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "*npp.*.installer.x64.exe").href | Select-Object -Index 0
+Start-BitsTransfer "$NotePadPlusPlus" -Destination "$TOOLS_DIR\NotePadPlusPlus.exe"

--- a/packages/base-utils-cornell/tools/preinstall.ps1
+++ b/packages/base-utils-cornell/tools/preinstall.ps1
@@ -5,8 +5,8 @@ $TOOLS_DIR = $PSScriptRoot
 Start-BitsTransfer "https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise64.msi" -Destination "$TOOLS_DIR\GoogleChromeStandaloneEnterprise64.msi"
 
 ## 7 Zip latest download link
-$7Zip = "https://www.7-zip.org/$((Invoke-WebRequest -Uri "https://www.7-zip.org/download.html" -UseBasicParsing | Select-Object -ExpandProperty Links | Where-Object -Property href -like "*-x64.msi")[0].href)"
-Start-BitsTransfer "$7Zip" -Destination "$TOOLS_DIR\7zip.msi"
+#$7Zip = "https://www.7-zip.org/$((Invoke-WebRequest -Uri "https://www.7-zip.org/download.html" -UseBasicParsing | Select-Object -ExpandProperty Links | Where-Object -Property href -like "*-x64.msi")[0].href)"
+#Start-BitsTransfer "$7Zip" -Destination "$TOOLS_DIR\7zip.msi"
 
 ## Notepad ++ Download
 ##example after website changes April 2026

--- a/packages/base-utils-cornell/tools/preinstall.ps1
+++ b/packages/base-utils-cornell/tools/preinstall.ps1
@@ -5,16 +5,13 @@ $TOOLS_DIR = $PSScriptRoot
 Start-BitsTransfer "https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise64.msi" -Destination "$TOOLS_DIR\GoogleChromeStandaloneEnterprise64.msi"
 
 ## 7 Zip latest download link
-#$7Zip = "https://www.7-zip.org/$((Invoke-WebRequest -Uri "https://www.7-zip.org/download.html" -UseBasicParsing | Select-Object -ExpandProperty Links | Where-Object -Property href -like "*-x64.msi")[0].href)"
-#Start-BitsTransfer "$7Zip" -Destination "$TOOLS_DIR\7zip.msi"
+$7Zip = "https://www.7-zip.org/$((Invoke-WebRequest -Uri "https://www.7-zip.org/download.html" -UseBasicParsing | Select-Object -ExpandProperty Links | Where-Object -Property href -like "*-x64.msi")[0].href)"
+Start-BitsTransfer "$7Zip" -Destination "$TOOLS_DIR\7zip.msi"
 
 ## Notepad ++ Download
 ##example after website changes April 2026
 ##https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.9.3/npp.8.9.3.Installer.x64.exe
 $linkPath = ((Invoke-WebRequest -URI https://notepad-plus-plus.org -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "/downloads/v*").href 
 $downloadurl = "https://notepad-plus-plus.org$linkpath"
-
-
-#$downloadurl = "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/"
 $NotePadPlusPlus = ((Invoke-WebRequest -URI $downloadurl -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "*npp.*.installer.x64.exe").href | Select-Object -Index 0
 Start-BitsTransfer "$NotePadPlusPlus" -Destination "$TOOLS_DIR\NotePadPlusPlus.exe"

--- a/packages/base-utils-cornell/tools/preinstall.ps1
+++ b/packages/base-utils-cornell/tools/preinstall.ps1
@@ -13,6 +13,8 @@ Start-BitsTransfer "$7Zip" -Destination "$TOOLS_DIR\7zip.msi"
 ##https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.9.3/npp.8.9.3.Installer.x64.exe
 #$linkPath = ((Invoke-WebRequest -URI https://notepad-plus-plus.org -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "/downloads/v*").href 
 #$downloadurl = "https://notepad-plus-plus.org$linkpath"
-$downloadurl = "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/"
-$NotePadPlusPlus = ((Invoke-WebRequest -URI $downloadurl -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "*npp.*.installer.x64.exe").href | Select-Object -Index 0
-Start-BitsTransfer "$NotePadPlusPlus" -Destination "$TOOLS_DIR\NotePadPlusPlus.exe"
+
+
+#$downloadurl = "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/"
+#$NotePadPlusPlus = ((Invoke-WebRequest -URI $downloadurl -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "*npp.*.installer.x64.exe").href | Select-Object -Index 0
+#Start-BitsTransfer "$NotePadPlusPlus" -Destination "$TOOLS_DIR\NotePadPlusPlus.exe"

--- a/packages/base-utils-cornell/tools/preinstall.ps1
+++ b/packages/base-utils-cornell/tools/preinstall.ps1
@@ -5,12 +5,13 @@ $TOOLS_DIR = $PSScriptRoot
 Start-BitsTransfer "https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise64.msi" -Destination "$TOOLS_DIR\GoogleChromeStandaloneEnterprise64.msi"
 
 ## 7 Zip latest download link
-$7Zip = "https://www.7-zip.org/$((Invoke-WebRequest -Uri "https://www.7-zip.org/download.html" -UseBasicParsing | Select-Object -ExpandProperty Links | Where-Object -Property href -like "*-x64.msi")[0].href)"
+#$7Zip = "https://www.7-zip.org/$((Invoke-WebRequest -Uri "https://www.7-zip.org/download.html" -UseBasicParsing | Select-Object -ExpandProperty Links | Where-Object -Property href -like "*-x64.msi")[0].href)"
+$7Zip = "$((Invoke-WebRequest -Uri "https://www.7-zip.org/download.html" -UseBasicParsing | Select-Object -ExpandProperty Links | Where-Object -Property href -like "*-x64.msi")[0].href)"
 Start-BitsTransfer "$7Zip" -Destination "$TOOLS_DIR\7zip.msi"
 
+
+
 ## Notepad ++ Download
-##example after website changes April 2026
-##https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.9.3/npp.8.9.3.Installer.x64.exe
 $linkPath = ((Invoke-WebRequest -URI https://notepad-plus-plus.org -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "/downloads/v*").href 
 $downloadurl = "https://notepad-plus-plus.org$linkpath"
 $NotePadPlusPlus = ((Invoke-WebRequest -URI $downloadurl -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "*npp.*.installer.x64.exe").href | Select-Object -Index 0

--- a/packages/base-utils-cornell/tools/preinstall.ps1
+++ b/packages/base-utils-cornell/tools/preinstall.ps1
@@ -9,7 +9,10 @@ $7Zip = "https://www.7-zip.org/$((Invoke-WebRequest -Uri "https://www.7-zip.org/
 Start-BitsTransfer "$7Zip" -Destination "$TOOLS_DIR\7zip.msi"
 
 ## Notepad ++ Download
-$linkPath = ((Invoke-WebRequest -URI https://notepad-plus-plus.org -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "/downloads/v*").href 
-$downloadurl = "https://notepad-plus-plus.org$linkpath"
+##example after website changes April 2026
+##https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.9.3/npp.8.9.3.Installer.x64.exe
+#$linkPath = ((Invoke-WebRequest -URI https://notepad-plus-plus.org -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "/downloads/v*").href 
+#$downloadurl = "https://notepad-plus-plus.org$linkpath"
+$downloadurl = "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/"
 $NotePadPlusPlus = ((Invoke-WebRequest -URI $downloadurl -UseBasicParsing) | Select-Object -ExpandProperty links | Where-Object -Property href -like "*npp.*.installer.x64.exe").href | Select-Object -Index 0
 Start-BitsTransfer "$NotePadPlusPlus" -Destination "$TOOLS_DIR\NotePadPlusPlus.exe"


### PR DESCRIPTION
Troubleshooting base-utils-cornell.  turned out to be a change in the 7-zip download URL. This tested out fine on a clean imagebuilder in test mode.