### PR TITLE
CNF Prolith License Server Update (#822)

### DIFF
--- a/packages/prolith2023b-ecornell/config.yml
+++ b/packages/prolith2023b-ecornell/config.yml
@@ -1,6 +1,6 @@
 Id:             'prolith2023b-ecornell'                ## Application package name ie. chrome-cornell
 Description:    'KLA Prolith 2023b'    ## Application packages description
-Version:        '23.2.0.0'                     ## Application version number - MUST BE in #.# format
+Version:        '23.3.0.0'                     ## Application version number - MUST BE in #.# format
 
 Install:                                    ## If there are installation files in a .zip to be installed, specify here
   - File:       '%INSTALL_DIR%\PROLITH_2023b_Install.exe'   ## Installation file
@@ -27,4 +27,4 @@ Registry:
                 SOFTWARE\FLEXlm License Manager:
                         PROLITH_LICENSE_FILE:
                                 Type:   'String'
-                                Value:  '@sanction.cnf.cornell.edu'
+                                Value:  '@pledge.cnf.cornell.edu'


### PR DESCRIPTION
* Add template file for PROLITH 2023b:
	modified:   prolith2023b-ecornell/config.yml
	modified:   prolith2023b-ecornell/tools/postinstall.ps1

* For prolith, bumped version number
	modified:   config.yml

* Changed Prolith license server registry
	modified:   prolith2023b-ecornell\config.yml