### PR TITLE
Revit

### DIFF
--- a/packages/revit-cornell/config.yml
+++ b/packages/revit-cornell/config.yml
@@ -1,5 +1,5 @@
 Id:             'revit-cornell'
-Description:    'Revit 2026 - build 1'
+Description:    'Revit 2026 - build 2'
 Version:        '2.23.0.517'
 
 Install:
@@ -17,7 +17,7 @@ Install:
     
 Applications:
     revit:
-        DisplayName:    'Revit 2027'
+        DisplayName:    'Revit 2026'
         Path:           '%PROGRAMFILES%\Autodesk\Revit 2026\Revit.exe'
         LaunchParams:   ''
         WorkDir:        ''

--- a/packages/revit-cornell/config.yml
+++ b/packages/revit-cornell/config.yml
@@ -30,6 +30,10 @@ Files:
                                                                 
 Environment:
     ADSKFLEX_LICENSE_FILE: '%REVIT_LICENSE_FILE%'
+    
+Scripts:
+    start:
+        System:  '%TOOLS_DIR%\startup.ps1'  ## Run at system startup
 
 Registry:
 


### PR DESCRIPTION
small application name change 2027->2026 and invoke licensing startup script on system start.